### PR TITLE
Fix assistant message history

### DIFF
--- a/agentica-dockerina/client/src/components/chat/ChatMessage.tsx
+++ b/agentica-dockerina/client/src/components/chat/ChatMessage.tsx
@@ -4,6 +4,28 @@ import rehypeHighlight from "rehype-highlight";
 import "highlight.js/styles/github-dark.css";
 import { markdownComponents } from "./MarkdownComponents";
 
+export function parseThinkToBlockquote(input: string | null | undefined): string {
+  if (input == null) {
+    // covers both null and undefined using == null idiom
+    return "";
+  }
+
+  return input.replace(/<think>([\s\S]*?)<\/think>/gi, (_match: string, inner: string) => {
+    const trimmed = inner.replace(/^\n+|\n+$/g, "");
+    if (trimmed === "") {
+      return "";
+    }
+
+    // explicit type so noImplicitAny error. split yields string[].
+    const lines: string[] = trimmed.split(/\r?\n/);
+    const quoted = lines
+      .map((line: string): string => `> ${line}`)
+      .join("\n");
+
+    return `\n${quoted}\n`;
+  });
+}
+
 interface Message {
   id: string;
   role: "user" | "assistant";
@@ -35,7 +57,7 @@ export function ChatMessage({ message }: ChatMessageProps) {
               rehypePlugins={[rehypeHighlight]}
               components={markdownComponents}
             >
-              {message.content}
+              {parseThinkToBlockquote(message.content)}
             </ReactMarkdown>
           </div>
         )}

--- a/agentica-dockerina/server/README.md
+++ b/agentica-dockerina/server/README.md
@@ -53,13 +53,18 @@ Change prompting/structures to reflect an Agentic behavior rather than forcing. 
 
 2. responses from `describe.ts` doesn't seem to be included in history. **Function call histories are provided to agents** BUT follow-up actions and error/problems reported by `describe.ts` is not conveyed which causes problems.
 
-3. **\*\(check notes)[RESOLVED\]** (mostly I think) Multiple function calls in some cases.
+3. **\*\[RESOLVED\] - (check notes)** (mostly I think) Multiple function calls in some cases.
 
-4. **\[RESOLVED\]** ~~broken function calls being filtered by ollama and ending the thinking process.~~ (**Edit**: Issue mostly resolved and also Ollama team working on fix.) 
+4. **\[RESOLVED\]** ~~broken function calls being filtered by ollama and ending the thinking process.~~ (**Edit**: Issue mostly resolved via prompting and also Ollama team working on fix.) 
 
 5. **\[RESOLVED\]** <u>`getApiFunctions` getting cut out when chat gets too long (out of context window), include in sysprompt or put it at last.</u>
 
-6. `<tool_response>` is too long, (exceeding context window size) <u>top level `output` field might be okay to purge during prompt</u>:
+6. **\[RESOLVED\] - (`stripThink` @ `agentica-dockerina/server/agentica/packages/core/src/factory/histories.ts`)** remove `<think>` tagged content from history (mostly irrelevant and massively fills up context window)
+
+7. **\[RESOLVED\] - (`parseThinkToBlockquote` @ `agentica-dockerina/client/src/components/chat/ChatMessage.tsx`)**
+  alongside no.6, format the content including `<think>` to seeprate from regular response
+
+8. `<tool_response>` is too long, (exceeding context window size) <u>top level `output` field might be okay to purge during prompt</u>:
 ```json
 {
   "function": {

--- a/agentica-dockerina/server/README.md
+++ b/agentica-dockerina/server/README.md
@@ -38,7 +38,7 @@ Change prompting/structures to reflect an Agentic behavior rather than forcing. 
 
 ### Problems
 
-1. **\[RESOLVING - (may just be a prompt fix.)\]** `histories.map(decodeHistory).flat()`@`/agentica/packages/core/src/orchestrate/describe.ts`: if function call history is empty, the prompt becomes like: (in ChatML)
+1. **\[RESOLVING - (may just be a prompt fix, low priority or not fixed)\]** `histories.map(decodeHistory).flat()`@`/agentica/packages/core/src/orchestrate/describe.ts`: if function call history is empty, the prompt becomes like: (in ChatML)
     ```text
     The user's choice of language is "English".
     The user's timezone is: "Asia/Seoul".
@@ -55,9 +55,69 @@ Change prompting/structures to reflect an Agentic behavior rather than forcing. 
 
 3. **\*\(check notes)[RESOLVED\]** (mostly I think) Multiple function calls in some cases.
 
-3. **\[RESOLVED\]** ~~broken function calls being filtered by ollama and ending the thinking process.~~ (**Edit**: Issue mostly resolved and also Ollama team working on fix.) 
+4. **\[RESOLVED\]** ~~broken function calls being filtered by ollama and ending the thinking process.~~ (**Edit**: Issue mostly resolved and also Ollama team working on fix.) 
 
-4. **\[RESOLVED\]** <u>`getApiFunctions` getting cut out when chat gets too long (out of context window), include in sysprompt or put it at last.</u>
+5. **\[RESOLVED\]** <u>`getApiFunctions` getting cut out when chat gets too long (out of context window), include in sysprompt or put it at last.</u>
+
+6. `<tool_response>` is too long, (exceeding context window size) <u>top level `output` field might be okay to purge during prompt</u>:
+```json
+{
+  "function": {
+    "protocol": "class",
+    "description": "Get all articles.\n\nList up every articles archived in the BBS DB.",
+    "parameters": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "required": [],
+      "$defs": {}
+    },
+    "output": {
+      "description": "List of every articles",
+      "type": "array",
+      "items": {
+        "description": "Description of the current {@link IBbsArticle} type:\n\n> Article entity.\n> \n> `IBbsArticle` is an entity representing an article in the BBS (Bulletin Board System).",
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Primary Key",
+            "description": "Primary Key.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "created_at": {
+            "title": "Creation time of the article",
+            "description": "Creation time of the article.",
+            "type": "string",
+            "format": "date-time"
+          },
+          ...
+          }
+        },
+        "required": [
+          "id",
+          "created_at",
+          "updated_at",
+          "title",
+          "body",
+          "thumbnail"
+        ]
+      }
+    }
+  },
+  "value": [
+    {
+      "id": "2a1dbb5b-e827-4134-accc-2c7e37c0471e",
+      "title": "Sample Article 1",
+      "body": "This is the content of the first sample article. It demonstrates how to create an article using the API.",
+      "thumbnail": "https://example.com/thumbnail1.jpg",
+      "created_at": "2025-07-31T14:37:04.808Z",
+      "updated_at": "2025-07-31T14:37:04.808Z"
+    },
+    ...
+  ]
+}
+```
 
 <u>**Interaction notes for \#3: (Problematic ones - function being called multiple times)**</u>
 
@@ -71,10 +131,12 @@ Change prompting/structures to reflect an Agentic behavior rather than forcing. 
 4. **`cancel.ts` is expected to cancel unused functions and `call.ts` is supposed to call all functions in `ctx.stack`.** (cancelling and calling the functions remove them from `ctx.stack`) But in some cases, `call.ts` doesn't cancel(all unused) or doesn't call(or fails to call) all the functions. `ctx.stack` is NOT emptied every 'turn' so it'll have a bug where prev. function stacks is called (via `call.ts`) confusing the function executions (running functions unprompted).
 
 > extra prompt logic needs to be added OR `executes.length === 0` @ `OllamaExecute.ts` conditional needs to be removed (any attempt to call the function removes it from `ctx.stack`) OR just empty `ctx.stack` every turn
-
+> 
 > also, if it were to work WITHOUT emptying `ctx.stack`, tool call/response history should be added at every loop (in the fcall loop). which seems like it isn't being done properly 
 
 ## Notes
+
+<u>**Raw ChatML is subject to change due to prompting updates and changes!!!**</u>
 
 **Raw ChatML for describe**
 ```

--- a/agentica-dockerina/server/agentica/packages/core/src/factory/histories.ts
+++ b/agentica-dockerina/server/agentica/packages/core/src/factory/histories.ts
@@ -15,6 +15,10 @@ import type { AgenticaSystemMessageHistory } from "../histories/AgenticaSystemMe
 import type { AgenticaUserMessageHistory } from "../histories/AgenticaUserMessageHistory";
 import type { IAgenticaHistoryJson } from "../json/IAgenticaHistoryJson";
 
+function stripThink(text: string): string {
+  return text.replace(/<think>[\s\S]*?<\/think>/g, "").trim();
+}
+
 // internal (** removed JSDoc for external access **)
 export function decodeHistory<Model extends ILlmSchema.Model>(history: AgenticaHistory<Model>): OpenAI.ChatCompletionMessageParam[] {
   // NO NEED TO DECODE DESCRIBE
@@ -96,7 +100,7 @@ export function decodeHistory<Model extends ILlmSchema.Model>(history: AgenticaH
     return [
       {
         role: "assistant",
-        content: history.text,
+        content: stripThink(history.text),
       },
     ];
   }

--- a/agentica-dockerina/server/src/OllamaOrchestrate/OllamaCall.ts
+++ b/agentica-dockerina/server/src/OllamaOrchestrate/OllamaCall.ts
@@ -51,6 +51,8 @@ import {
   cancelFunctionFromContext,
 } from "@agentica/core";
 
+import { parseThinkToBlockquote } from "../utils/thinkParser";
+
 export async function ollamaCall<Model extends ILlmSchema.Model>(
   ctx: AgenticaContext<Model>, // | MicroAgenticaContext<Model>,
   operations: AgenticaOperation<Model>[],
@@ -188,7 +190,7 @@ export async function ollamaCall<Model extends ILlmSchema.Model>(
     ) {
       const text: string = choice.message.content;
       const event: AgenticaAssistantMessageEvent = creatAssistantMessageEvent({
-        get: () => "## [CALL AGENT]\n\n" + text,
+        get: () => "## *CALL AGENT*\n\n" + parseThinkToBlockquote(text),
         done: () => true,
         stream: toAsyncGenerator(text),
         join: async () => Promise.resolve(text),

--- a/agentica-dockerina/server/src/OllamaOrchestrate/OllamaCall.ts
+++ b/agentica-dockerina/server/src/OllamaOrchestrate/OllamaCall.ts
@@ -51,7 +51,7 @@ import {
   cancelFunctionFromContext,
 } from "@agentica/core";
 
-import { parseThinkToBlockquote } from "../utils/thinkParser";
+// import { parseThinkToBlockquote } from "../utils/thinkParser";
 
 export async function ollamaCall<Model extends ILlmSchema.Model>(
   ctx: AgenticaContext<Model>, // | MicroAgenticaContext<Model>,
@@ -190,7 +190,7 @@ export async function ollamaCall<Model extends ILlmSchema.Model>(
     ) {
       const text: string = choice.message.content;
       const event: AgenticaAssistantMessageEvent = creatAssistantMessageEvent({
-        get: () => "## *CALL AGENT*\n\n" + parseThinkToBlockquote(text),
+        get: () => "## *CALL AGENT*\n\n" + text,
         done: () => true,
         stream: toAsyncGenerator(text),
         join: async () => Promise.resolve(text),

--- a/agentica-dockerina/server/src/OllamaOrchestrate/OllamaCancel.ts
+++ b/agentica-dockerina/server/src/OllamaOrchestrate/OllamaCancel.ts
@@ -45,7 +45,7 @@ interface IFailure {
   validation: IValidation.IFailure;
 }
 
-export async function OllamaCancel<Model extends ILlmSchema.Model>(
+export async function ollamaCancel<Model extends ILlmSchema.Model>(
   ctx: AgenticaContext<Model>,
 ): Promise<void> {
   if (ctx.operations.divided === undefined) {
@@ -104,6 +104,7 @@ async function step<Model extends ILlmSchema.Model>(
   retry: number,
   failures?: IFailure[],
 ): Promise<void> {
+  console.log("[OllamaCancel.ts] `ctx.stack.length` is <", ctx.stack.length, ">, cancel.ts step requested.");
   // ----
   // EXECUTE CHATGPT API
   // ----

--- a/agentica-dockerina/server/src/OllamaOrchestrate/OllamaDescribe.ts
+++ b/agentica-dockerina/server/src/OllamaOrchestrate/OllamaDescribe.ts
@@ -28,6 +28,8 @@ import {
     streamDefaultReaderToAsyncGenerator, StreamUtil,
 } from "@agentica/core"
 
+import { parseThinkToBlockquote } from "../utils/thinkParser";
+
 export async function ollamaDescribe<Model extends ILlmSchema.Model>(
   ctx: AgenticaContext<Model> | MicroAgenticaContext<Model>,
   histories: AgenticaExecuteHistory<Model>[],
@@ -100,7 +102,8 @@ export async function ollamaDescribe<Model extends ILlmSchema.Model>(
           executes: histories,
           stream: streamDefaultReaderToAsyncGenerator(mpsc.consumer.getReader()),
           done: () => mpsc.done(),
-          get: () => "## [DESCRIBE AGENT]\n\n" + (describeContext[choice.index]?.content ?? ""),
+          get: () => "## *DESCRIBE AGENT*\n\n" 
+            + (parseThinkToBlockquote(describeContext[choice.index]?.content) ?? ""),
           join: async () => {
             await mpsc.waitClosed();
             return describeContext[choice.index]!.content;

--- a/agentica-dockerina/server/src/OllamaOrchestrate/OllamaDescribe.ts
+++ b/agentica-dockerina/server/src/OllamaOrchestrate/OllamaDescribe.ts
@@ -28,7 +28,7 @@ import {
     streamDefaultReaderToAsyncGenerator, StreamUtil,
 } from "@agentica/core"
 
-export async function OllamaDescribe<Model extends ILlmSchema.Model>(
+export async function ollamaDescribe<Model extends ILlmSchema.Model>(
   ctx: AgenticaContext<Model> | MicroAgenticaContext<Model>,
   histories: AgenticaExecuteHistory<Model>[],
 ): Promise<void> {
@@ -121,5 +121,5 @@ export async function OllamaDescribe<Model extends ILlmSchema.Model>(
 }
 
 export const ChatGptDescribeFunctionAgent = {
-  execute: OllamaDescribe,
+  execute: ollamaDescribe,
 };

--- a/agentica-dockerina/server/src/OllamaOrchestrate/OllamaDescribe.ts
+++ b/agentica-dockerina/server/src/OllamaOrchestrate/OllamaDescribe.ts
@@ -28,7 +28,7 @@ import {
     streamDefaultReaderToAsyncGenerator, StreamUtil,
 } from "@agentica/core"
 
-import { parseThinkToBlockquote } from "../utils/thinkParser";
+// import { parseThinkToBlockquote } from "../utils/thinkParser";
 
 export async function ollamaDescribe<Model extends ILlmSchema.Model>(
   ctx: AgenticaContext<Model> | MicroAgenticaContext<Model>,
@@ -103,7 +103,7 @@ export async function ollamaDescribe<Model extends ILlmSchema.Model>(
           stream: streamDefaultReaderToAsyncGenerator(mpsc.consumer.getReader()),
           done: () => mpsc.done(),
           get: () => "## *DESCRIBE AGENT*\n\n" 
-            + (parseThinkToBlockquote(describeContext[choice.index]?.content) ?? ""),
+            + (describeContext[choice.index]?.content ?? ""),
           join: async () => {
             await mpsc.waitClosed();
             return describeContext[choice.index]!.content;

--- a/agentica-dockerina/server/src/OllamaOrchestrate/OllamaExecute.ts
+++ b/agentica-dockerina/server/src/OllamaOrchestrate/OllamaExecute.ts
@@ -10,7 +10,7 @@ import {
 // needs to be replced if extra custom orchestrations are added
 import { ollamaSelect as select } from "./OllamaSelect";
 import { ollamaCall as call } from "./OllamaCall";
-import { OllamaCancel as cancel } from "./OllamaCancel";
+import { ollamaCancel as cancel } from "./OllamaCancel";
 
 import {
   // orchestrate
@@ -75,10 +75,10 @@ export function ollamaExecute<Model extends ILlmSchema.Model>(executor: Partial<
       }
       else {
         // CANCEL CANDIDATE FUNCTIONS
-        console.log("[OllamaExecute.ts] `ctx.stack.length` is <", ctx.stack.length, ">, calling cancel.ts");
         await (executor?.cancel ?? cancel)(ctx);
-        console.log("[OllamaExecute.ts] cancel complete, `ctx.stack.length` is now <", ctx.stack.length, ">");
+        
       }
+      console.log("[OllamaExecute.ts] `ctx.stack.length` is now <", ctx.stack.length, ">");
     }
 
     // // Empty stack if function(s) are not used

--- a/agentica-dockerina/server/src/OllamaOrchestrate/OllamaSelect.ts
+++ b/agentica-dockerina/server/src/OllamaOrchestrate/OllamaSelect.ts
@@ -37,7 +37,7 @@ import {
   selectFunctionFromContext,
 } from "@agentica/core";
 
-import { parseThinkToBlockquote } from "../utils/thinkParser";
+// import { parseThinkToBlockquote } from "../utils/thinkParser";
 
 import type { __IChatFunctionReference } from "../function-refs/__IChatFunctionReference"
 import type { __IChatSelectFunctionsApplication } from "../function-refs/__IChatSelectFunctionsApplication"
@@ -287,7 +287,7 @@ async function step<Model extends ILlmSchema.Model>(
         stream: toAsyncGenerator(choice.message.content),
         join: async () => Promise.resolve(choice.message.content!),
         done: () => true,
-        get: () => "## *SELECT AGENT*\n\n" + parseThinkToBlockquote(choice.message.content!), // string
+        get: () => "## *SELECT AGENT*\n\n" + choice.message.content!, // string
       });
       ctx.dispatch(event);
     }

--- a/agentica-dockerina/server/src/OllamaOrchestrate/OllamaSelect.ts
+++ b/agentica-dockerina/server/src/OllamaOrchestrate/OllamaSelect.ts
@@ -37,7 +37,7 @@ import {
   selectFunctionFromContext,
 } from "@agentica/core";
 
-// import { factory, orchestrate, utils, constants } from "@agentica/core"
+import { parseThinkToBlockquote } from "../utils/thinkParser";
 
 import type { __IChatFunctionReference } from "../function-refs/__IChatFunctionReference"
 import type { __IChatSelectFunctionsApplication } from "../function-refs/__IChatSelectFunctionsApplication"
@@ -287,7 +287,7 @@ async function step<Model extends ILlmSchema.Model>(
         stream: toAsyncGenerator(choice.message.content),
         join: async () => Promise.resolve(choice.message.content!),
         done: () => true,
-        get: () => "## [SELECT AGENT]\n\n" + choice.message.content!, // string
+        get: () => "## *SELECT AGENT*\n\n" + parseThinkToBlockquote(choice.message.content!), // string
       });
       ctx.dispatch(event);
     }

--- a/agentica-dockerina/server/src/function-refs/__IChatCancelFunctionsApplication.ts
+++ b/agentica-dockerina/server/src/function-refs/__IChatCancelFunctionsApplication.ts
@@ -2,22 +2,15 @@ import type { __IChatFunctionReference } from "./__IChatFunctionReference";
 
 export interface __IChatCancelFunctionsApplication {
   /**
-   * Cancel a function from the candidate list to call.
+   * Cancels selected functions from the candidate call list.
    *
-   * If you A.I. agent has understood that the user wants to cancel
-   * some candidate functions to call from the conversation, please cancel
-   * them through this function.
+   * Use this function when:
+   * - The user explicitly requests cancellation of certain candidate functions.
+   * - Multiple candidate functions are selected due to unclear or ambiguous user input (candidate pooling), and unnecessary functions need removal.
    *
-   * Also, when you A.I. find a function that has been selected by the candidate
-   * pooling, cancel the function by calling this function. For reference, the
-   * candidate pooling means that user wants only one function to call, but you A.I.
-   * agent selects multiple candidate functions because the A.I. agent can't specify
-   * only one thing due to lack of specificity or homogeneity of candidate functions.
+   * To cancel the same function multiple times, include its name repeatedly in the `functions` array.
    *
-   * Additionally, if you A.I. agent wants to cancel same function multiply, you can
-   * do it by assigning the same function name multiply in the `functions` property.
-   *
-   * @param props Properties of the function
+   * @param props Properties of the function.
    */
   cancelFunctions: (props: __IChatFunctionReference.IProps) => Promise<void>;
 }

--- a/agentica-dockerina/server/src/index.ts
+++ b/agentica-dockerina/server/src/index.ts
@@ -30,8 +30,8 @@ import type { ILlmSchema } from "@samchon/openapi/lib/structures/ILlmSchema";
 import { ollamaSelect } from "./OllamaOrchestrate/OllamaSelect";
 import { ollamaCall } from "./OllamaOrchestrate/OllamaCall";
 import { ollamaExecute } from "./OllamaOrchestrate/OllamaExecute";
-import { OllamaCancel } from "./OllamaOrchestrate/OllamaCancel";
-import { OllamaDescribe } from "./OllamaOrchestrate/OllamaDescribe";
+import { ollamaCancel } from "./OllamaOrchestrate/OllamaCancel";
+import { ollamaDescribe } from "./OllamaOrchestrate/OllamaDescribe";
 
 const getPromptHistories = async (
   id: string,
@@ -68,7 +68,7 @@ const main = async (): Promise<void> => {
               apiKey: SGlobal.env.OPENAI_API_KEY, // dummy key
               baseURL: "http://localhost:8000/v1" // http://localhost:11434/v1 for direct call
             }),
-            model: "qwen3-14b-8k" // ollama models (NO QWEN3 SCHEMA YET)
+            model: "qwen3-14b-4k" // ollama models (NO QWEN3 SCHEMA YET)
             // model: "gpt-4o-mini" // chatgpt API
           },
 
@@ -117,7 +117,7 @@ const main = async (): Promise<void> => {
               ].join("\n"),
 
               cancel: () => [
-                "You are a helpful assistant for cancelling functions which are prepared to call.",
+                "You are an agent for cancelling functions which are prepared to call.",
                 "Use the supplied tools to select some functions to cancel of `getApiFunctions()` returned.",
                 "If you can't find any proper function to select, don't talk, don't do anything.",
                 ].join("\n"),
@@ -128,8 +128,8 @@ const main = async (): Promise<void> => {
             executor: ollamaExecute<ModelType>({
               select: ollamaSelect,
               call: ollamaCall,
-              cancel: OllamaCancel,
-              describe: OllamaDescribe,
+              cancel: ollamaCancel,
+              describe: ollamaDescribe,
             }),
 
             // [Custom added parameters] NOTE: seems broken? in-line commands or other methods needed.

--- a/agentica-dockerina/server/src/index.ts
+++ b/agentica-dockerina/server/src/index.ts
@@ -80,12 +80,13 @@ const main = async (): Promise<void> => {
             // timezone: "",
             // ------------------
 
-            // prompting order: `.../src/orchestrate/select.ts` is used... (idk why not `initialize.ts`)
-            // [Sysprompt gets priority anyways in ChatML, order for 'system' DOES NOT MATTER]
-            //    COMMON -> <TOOL_CALLS(history) & TOOL> -> <USER INP> -> SELECT(problematic)
+            /* prompting order: `.../src/orchestrate/select.ts` is used... (idk why not `initialize.ts`)
+            [Sysprompt gets priority anyways in ChatML, order for 'system' DOES NOT MATTER]
+              COMMON -> <TOOL_CALLS(history) & TOOL> -> <USER INP> -> SELECT(problematic)
             
-            // hardcoded prompt orders & structure, CANNOT change -> Modding needed
-            // @ agentica/packages/core/src/orchestrate
+            hardcoded prompt orders & structure, CANNOT change -> Modding needed
+            @ agentica/packages/core/src/orchestrate
+            */
 
             systemPrompt: {
               common: () => [

--- a/agentica-dockerina/server/src/utils/thinkParser.ts
+++ b/agentica-dockerina/server/src/utils/thinkParser.ts
@@ -1,0 +1,21 @@
+export function parseThinkToBlockquote(input: string | null | undefined): string {
+  if (input == null) {
+    // covers both null and undefined using == null idiom
+    return "";
+  }
+
+  return input.replace(/<think>([\s\S]*?)<\/think>/gi, (_match: string, inner: string) => {
+    const trimmed = inner.replace(/^\n+|\n+$/g, "");
+    if (trimmed === "") {
+      return "";
+    }
+
+    // explicit type so noImplicitAny error. split yields string[].
+    const lines: string[] = trimmed.split(/\r?\n/);
+    const quoted = lines
+      .map((line: string): string => `> ${line}`)
+      .join("\n");
+
+    return `\n${quoted}\n`;
+  });
+}


### PR DESCRIPTION
## Summary
- handle `<think>` tags by stripping them from assistant messages

## Testing
- `pnpm build` *(fails: proxy response 403 when downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_6887772d203c83308320d6adbb55c165